### PR TITLE
Experiment sharding

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -1023,7 +1023,7 @@ class PeftPromptTuning(ModuleBase):
         (
             tokenize_function,
             requires_unwrapping,
-        ) = base_model.build_task_tokenize_function(
+        ) = base_model.build_task_tokenize_closure(
             tokenizer, max_source_length, max_target_length, verbalizer, task_ids=0
         )
         mapped_stream = train_stream.map(tokenize_function)

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -597,6 +597,8 @@ class TextGeneration(ModuleBase):
                 "max_target_length": max_target_length,
             },
         )
+        if shuffle:
+            return mapped_dataset.shuffle()
         return mapped_dataset
 
     @staticmethod

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -598,7 +598,7 @@ class TextGeneration(ModuleBase):
             },
         )
         if shuffle:
-            return mapped_dataset.shuffle()
+            return mapped_dataset.shuffle(seed=TextGeneration.RANDOM_SEED)
         return mapped_dataset
 
     @staticmethod

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -373,8 +373,13 @@ class TextGeneration(ModuleBase):
         # because this case of multiple devices, this whole program gets run
         # in parallel, so the model might still be in "write" mode on 1 process
         # while we try to read it in below process.
+        #
+        # Note that we forward the base model tokenizer instance to bootstrap to avoid
+        # dealing with temporarily exporting and reloading the tokenizer off of the trainer.
         model = resource_type.bootstrap(
-            checkpoint_dir, checkpoint_dir, torch_dtype=torch_dtype
+            model_name=checkpoint_dir,
+            tokenizer_name=base_model.tokenizer,
+            torch_dtype=torch_dtype,
         )
 
         return cls(

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -14,7 +14,7 @@
 
 
 # Standard
-from typing import Optional
+from typing import Optional, Union
 import gc
 import os
 import tempfile
@@ -252,7 +252,7 @@ class TextGeneration(ModuleBase):
 
         error.type_check("<NLP03221895E>", PretrainedModelBase, base_model=base_model)
         ## Generate data loader from stream
-        training_dataset: IterableDataset = cls._preprocess_function(
+        training_dataset: Union[Dataset, TransformersIterableDataset] = cls._preprocess_function(
             base_model=base_model,
             train_stream=train_stream,
             tokenizer=base_model.tokenizer,
@@ -336,8 +336,8 @@ class TextGeneration(ModuleBase):
                 # NOTE: This is explicitly set to false since it will
                 # negatively impact the performance
                 "full_determinism": False,
-                # Required for iterable dataset - TODO: for now we don't support this
-                "max_steps": 1,
+                # Required for iterable dataset
+                "max_steps": cls.infer_max_steps(num_epochs, batch_size, training_dataset),
                 # Some interesting parameters:
                 "auto_find_batch_size": True,
                 # NOTE: following can override above arguments in order
@@ -623,6 +623,20 @@ class TextGeneration(ModuleBase):
         # save tokenizer explicitly
         base_model.tokenizer.save_pretrained(checkpoint_dir)
 
+    @staticmethod
+    def infer_max_steps(num_epochs: int, batch_size: int, training_dataset: Union[Dataset, TransformersIterableDataset]):
+        # Calculate the number of samples that we have
+        if isinstance(training_dataset, Dataset):
+            data_len = len(training_dataset)
+        else:
+            data_len = 0
+            for _ in training_dataset:
+                data_len += 1
+        # Figure out how many batches we'll have per epoch; we assume drop_last=True for now
+        num_batches = data_len // batch_size
+        num_steps = num_batches * num_epochs
+        log.debug("Number of inferred steps: [%s]", num_steps)
+        return num_steps
 
 def get(train_stream):
     for data in train_stream:

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -384,7 +384,7 @@ class TextGeneration(ModuleBase):
             # dealing with temporarily exporting and reloading the tokenizer off of the trainer.
             model = resource_type.bootstrap(
                 model_name=checkpoint_dir,
-                tokenizer_name=base_model.tokenizer,
+                tokenizer_name=checkpoint_dir,
                 torch_dtype=torch_dtype,
             )
 
@@ -571,7 +571,7 @@ class TextGeneration(ModuleBase):
         max_source_length: int,
         max_target_length: int,
         shuffle: bool,
-        use_iterable_dataset: bool, # Currently not publicly exposed
+        use_iterable_dataset: bool,
     ):
         """Pre-process each example to get it prepared for training."""
         dataset_type = TransformersIterableDataset if use_iterable_dataset else Dataset

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -171,7 +171,6 @@ class TextGeneration(ModuleBase):
         accumulate_steps: int = 32,
         random_seed: int = RANDOM_SEED,
         lr: float = 2e-5,
-        use_iterable_dataset: bool = False,
         **kwargs,
     ) -> "TextGeneration":
         """
@@ -200,10 +199,6 @@ class TextGeneration(ModuleBase):
                 Number of steps to use for gradient accumulation. Default: 1.
             lr: float
                 Learning rate to be used while tuning model. Default: 2e-5.
-            use_iterable_dataset: bool
-                Indicates that we should use an iterable dataset. If this is set to False, the
-                whole dataset will be loaded into memory, but the sharded training will be faster.
-                Default: False
             **kwargs:
                 Arguments supported by HF Training Arguments.
                 TrainingArguments:
@@ -259,7 +254,7 @@ class TextGeneration(ModuleBase):
             max_source_length=max_source_length,
             max_target_length=max_target_length,
             shuffle=True,
-            use_iterable_dataset=use_iterable_dataset,
+            use_iterable_dataset=False, # TODO: We'll expose this in the future!
         )
 
         ### Dtype based processing
@@ -336,8 +331,8 @@ class TextGeneration(ModuleBase):
                 # NOTE: This is explicitly set to false since it will
                 # negatively impact the performance
                 "full_determinism": False,
-                # Required for iterable dataset
-                "max_steps": 1,
+                # Required for iterable dataset - TODO: for now we don't support this
+                # "max_steps": 1,
                 # Some interesting parameters:
                 "auto_find_batch_size": True,
                 # NOTE: following can override above arguments in order
@@ -571,24 +566,36 @@ class TextGeneration(ModuleBase):
         max_source_length: int,
         max_target_length: int,
         shuffle: bool,
-        use_iterable_dataset: bool,
+        use_iterable_dataset: bool, # Currently not publicly exposed
     ):
         """Pre-process each example to get it prepared for training."""
         dataset_type = TransformersIterableDataset if use_iterable_dataset else Dataset
         log.debug("Loading dataset class: [%s]", dataset_type.__name__)
-        dataset = dataset_type.from_generator(
-            get, gen_kwargs={"train_stream": train_stream}
-        )
-        mapped_dataset = dataset.map(
-            base_model.tokenize_function,
-            fn_kwargs={
-                "tokenizer": tokenizer,
-                "max_source_length": max_source_length,
-                "max_target_length": max_target_length,
-            },
-        )
+        fn_kwargs = {
+            "tokenizer": tokenizer,
+            "max_source_length": max_source_length,
+            "max_target_length": max_target_length,
+        }
+
+        if base_model.REQUIRES_TOKEN_UNWRAPPING:
+            # HACK: Currently Causal LM requires special handling to unpack the nested
+            # stream yielded by the tokenizer. For now, we get around this by handling
+            # map on the datastream so we can flatten it, but this is not ideal.
+            mapped_dataset = Dataset.from_list(
+                list(train_stream.map(base_model.tokenize_function, **fn_kwargs).flatten())
+            )
+        else:
+            dataset = dataset_type.from_generator(
+                get, gen_kwargs={"train_stream": train_stream}
+            )
+            mapped_dataset = dataset.map(
+                base_model.tokenize_function,
+                fn_kwargs=fn_kwargs,
+            )
+
         if shuffle:
             return mapped_dataset.shuffle(seed=TextGeneration.RANDOM_SEED)
+
         return mapped_dataset
 
     @staticmethod
@@ -619,9 +626,8 @@ class TextGeneration(ModuleBase):
 def get(train_stream):
     for data in train_stream:
         # Handle token unwrapping for causal language modeling
-        if isinstance(data, DataStream):
-            for datum in data:
-               yield {"input": datum.input, "output": datum.output}
-        # Otherwise assume we directly yield dictionaries
-        else:
+        if isinstance(data, GenerationTrainRecord):
             yield {"input": data.input, "output": data.output}
+        # Otherwise assume we directly yield tokenized results
+        else:
+            yield data

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -574,29 +574,11 @@ class TextGeneration(ModuleBase):
         use_iterable_dataset: bool,
     ):
         """Pre-process each example to get it prepared for training."""
-        if use_iterable_dataset:
-            # Generator based
-            log.debug("Loading data as an iterable dataset")
-            dataset = TransformersIterableDataset.from_generator(
-                get, gen_kwargs={"train_stream": train_stream}
-            )
-        else:
-            # Convert the train stream to an normal dataset in memory
-            log.debug("Loading data as a normal dataset")
-            # TODO: Optimize and clean this up!
-            inputs = []
-            outputs = []
-            if base_model.REQUIRES_TOKEN_UNWRAPPING:
-                for substream in train_stream:
-                    for data in substream:
-                        inputs.append(data.input)
-                        outputs.append(data.output)
-            else:
-                for data in train_stream:
-                    inputs.append(data.input)
-                    outputs.append(data.output)
-            dataset = Dataset.from_dict({"input": inputs, "output": outputs})
-        # Map our HF datasets; with our tokenizer functions
+        dataset_type = TransformersIterableDataset if use_iterable_dataset else Dataset
+        log.debug("Loading dataset class: [%s]", dataset_type.__name__)
+        dataset = dataset_type.from_generator(
+            get, gen_kwargs={"train_stream": train_stream}
+        )
         mapped_dataset = dataset.map(
             base_model.tokenize_function,
             fn_kwargs={

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -23,7 +23,6 @@ from datasets import Dataset
 from datasets import IterableDataset as TransformersIterableDataset
 from torch.utils.data import IterableDataset
 from transformers import AutoConfig, AutoTokenizer
-import datasets
 import torch
 
 # First Party
@@ -42,7 +41,6 @@ from ...resources.pretrained_model import (
     HFAutoSeq2SeqLM,
     PretrainedModelBase,
 )
-from ...toolkit.data_stream_wrapper import SimpleIterableStreamWrapper
 from ...toolkit.data_type_utils import get_torch_dtype, str_to_torch_dtype
 from ...toolkit.torch_run import get_torch_elastic_launch_config
 
@@ -568,6 +566,8 @@ class TextGeneration(ModuleBase):
         use_iterable_dataset: bool,
     ):
         """Pre-process each example to get it prepared for training."""
+        if base_model.REQUIRES_TOKEN_UNWRAPPING:
+            raise NotImplementedError("Token unwrapping not implemented for fine tuning data prep")
         if use_iterable_dataset:
             # Generator based
             log.debug("Loading data as an iterable dataset")
@@ -577,15 +577,15 @@ class TextGeneration(ModuleBase):
         else:
             # Convert the train stream to an normal dataset in memory
             log.debug("Loading data as a normal dataset")
-            # TODO - this can probably be optimized a bit
             inputs = []
             outputs = []
             for datum in train_stream:
                 inputs.append(datum.input)
                 outputs.append(datum.output)
             dataset = Dataset.from_dict({"input": inputs, "output": outputs})
+        # Map our HF datasets; with our tokenizer functions
         mapped_dataset = dataset.map(
-            tokenize_function_seq2seq,
+            base_model.tokenize_function,
             fn_kwargs={
                 "tokenizer": tokenizer,
                 "max_source_length": max_source_length,
@@ -619,48 +619,3 @@ class TextGeneration(ModuleBase):
 def get(train_stream):
     for data in train_stream:
         yield {"input": data.input, "output": data.output}
-
-
-def tokenize_function_seq2seq(
-    example: GenerationTrainRecord,
-    tokenizer: "AutoTokenizer",
-    max_source_length: int,
-    max_target_length: int,
-):
-    """Tokenization function to be used for seq2seq training; this function consumes a
-    GenerationTrainRecord object and postprocesses by ignoring pad tokens in the
-    label IDs; currently it does not allow us to use a verbalizer.
-
-    Args:
-        example: GenerationTrainRecord
-            Training data model object to convert a form we can learn on.
-
-    Returns:
-        transformers.tokenization_utils_base.BatchEncoding
-            encoded tokenization output corresponding to the input example.
-    """
-    IGNORE_ID = -100
-    source = example["input"]
-
-    targets = example["output"]
-    model_inputs = tokenizer(
-        source,
-        max_length=max_source_length,
-        padding="max_length",
-        truncation=True,
-    )
-    labels = tokenizer(
-        targets,
-        max_length=max_target_length,
-        padding="max_length",
-        truncation=True,
-    )
-
-    labels = labels["input_ids"]
-
-    labels = list(
-        map(lambda x: IGNORE_ID if x == tokenizer.pad_token_id else x, labels)
-    )
-    model_inputs["labels"] = labels
-
-    return model_inputs

--- a/caikit_nlp/modules/text_generation/text_generation_local.py
+++ b/caikit_nlp/modules/text_generation/text_generation_local.py
@@ -298,7 +298,7 @@ class TextGeneration(ModuleBase):
         if extra_training_args:
             log.warning(
                 "<NLP24424909W>",
-                f"{extra_training_args} parameter(s) not allowed by {cls.name} currently and will be ignored!",
+                f"{extra_training_args} parameter(s) not allowed by {cls.__name__} currently and will be ignored!",
             )
 
         processing_configuration = {}

--- a/caikit_nlp/resources/pretrained_model/base.py
+++ b/caikit_nlp/resources/pretrained_model/base.py
@@ -133,7 +133,7 @@ class PretrainedModelBase(ABC, ModuleBase):
         Args:
             model_name (str)
                 The name/path of the HF sequence classifier model
-            tokenizer_name (Optional[Union[str, PreTrainedTokenizerBase]])
+            tokenizer_name (Optional[str]
                 The name/path of the HF tokenizer model (matches model_name if
                 not given) or an instance of a loaded tokenizer.
                 NOTE: If a loaded tokenizer is provided, and it doesn't have
@@ -160,41 +160,34 @@ class PretrainedModelBase(ABC, ModuleBase):
             "Must provide path to tokenizer if model_name is a path",
         )
         torch_dtype = get_torch_dtype(torch_dtype)
-        # Check if we passed the tokenizer directly; for now, we keep
-        # the arg name tokenizer_name for compatibility reasons
-        if isinstance(tokenizer_name, PreTrainedTokenizerBase):
-            log.debug("Bootstrapping with in-memory tokenizer")
-            tokenizer = tokenizer_name
-
-        else:
-            if tokenizer_name is None:
-                tokenizer_name = model_name
-
-            if not os.path.isdir(tokenizer_name) and tokenizer_name != model_name:
-                log.warning(
-                    "Bootstrapping with mismatched tokenizer (%s) / model (%s)",
-                    tokenizer_name,
-                    model_name,
-                )
-
-            # Figure out the right padding side based on the name of the HF model
-            # NOTE: This matches models whose name includes the left-pad types as a
-            #   substring and not just as an exact match.
-            if padding_side is None:
-                padding_side = (
-                    "left"
-                    if any(k in model_name for k in cls._LEFT_PAD_MODEL_TYPES)
-                    else "right"
-                )
-
-            # Load the tokenizer
-            tokenizer = AutoTokenizer.from_pretrained(
+        if tokenizer_name is None:
+            tokenizer_name = model_name
+        if not os.path.isdir(tokenizer_name) and tokenizer_name != model_name:
+            log.warning(
+                "Bootstrapping with mismatched tokenizer (%s) / model (%s)",
                 tokenizer_name,
-                local_files_only=not get_config().allow_downloads,
-                padding_side=padding_side,
-                # We can't disable use_fast otherwise unit test fails
-                # use_fast=False,
+                model_name,
             )
+
+        # Figure out the right padding side based on the name of the HF model
+        # NOTE: This matches models whose name includes the left-pad types as a
+        #   substring and not just as an exact match.
+        if padding_side is None:
+            padding_side = (
+                "left"
+                if any(k in model_name for k in cls._LEFT_PAD_MODEL_TYPES)
+                else "right"
+            )
+
+        # Load the tokenizer and set up the pad token if needed
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_name,
+            local_files_only=not get_config().allow_downloads,
+            padding_side=padding_side,
+            # We can't disable use_fast otherwise unit test fails
+            # use_fast=False,
+        )
+
         # set up the pad token if needed; note that this will mutate
         # the tokenizer that is pass as an argument if one is provided.
         if tokenizer.pad_token_id is None:

--- a/caikit_nlp/resources/pretrained_model/base.py
+++ b/caikit_nlp/resources/pretrained_model/base.py
@@ -14,6 +14,7 @@
 
 # Standard
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import Callable, List, Optional, Tuple, Type, Union
 import json
 import os
@@ -32,12 +33,13 @@ import torch
 
 # First Party
 from caikit import get_config
+from caikit.core.data_model import DataStream
 from caikit.core.modules import ModuleBase, ModuleConfig, ModuleSaver
 from caikit.core.toolkit import error_handler
 import alog
 
 # Local
-from ...data_model import PromptOutputModelType
+from ...data_model import GenerationTrainRecord, PromptOutputModelType
 from ...toolkit.data_type_utils import get_torch_dtype, str_to_torch_dtype
 
 log = alog.use_channel("HFRBAS")
@@ -50,6 +52,12 @@ class PretrainedModelBase(ABC, ModuleBase):
     _TOK_ARTIFACTS_CONFIG_KEY = "tokenizer_artifacts"
     _MODEL_ARTIFACTS_CONFIG_KEY = "model_artifacts"
     _LEFT_PAD_MODEL_TYPES = ("gpt", "opt", "bloom")
+
+    @classmethod
+    @property
+    def REQUIRES_TOKEN_UNWRAPPING(cls) -> str:
+        """Most models don't need token unwrapping from their tokenizer closures"""
+        return False
 
     ## Abstract Interface ######################################################
 
@@ -74,7 +82,6 @@ class PretrainedModelBase(ABC, ModuleBase):
         """All classes must indicate the model types supported by the resource"""
 
     ## Shared Implementation ###################################################
-
     def __init__(
         self,
         tokenizer: AutoTokenizer,
@@ -279,7 +286,6 @@ class PretrainedModelBase(ABC, ModuleBase):
         trainer_arguments = {
             "train_dataset": train_dataset,
             "data_collator": data_collator,
-            # "tokenizer": self._tokenizer,
             "optimizers": optimizers,
             "eval_dataset": eval_dataset,
         }
@@ -316,20 +322,55 @@ class PretrainedModelBase(ABC, ModuleBase):
         """Return number of applicable transformer submodules"""
         return 1
 
+    @staticmethod
+    def decompose_example_io(example: Union[GenerationTrainRecord, Mapping]):
+        """Given an example, which might be a number of supported types,
+        extract the input / output texts. Depending on the manner in which
+        the sample is being leveraged, this might be a raw data model object,
+        a dict, or some other mappable, e.g., a HF dataset LazyRow.
+        
+        args:
+            example: Union[GenerationTrainRecord, Mapping]
+                Objects whose input / output we want to retrieve.
+
+        Returns:
+            Tuple[str, str]
+                Input & Output strings.
+        """
+        if isinstance(example, GenerationTrainRecord):
+            return example.input, example.output
+        # TODO: probably a good idea to add some error handling here;
+        # For now, we don't since situations in which we call this
+        # internally should generally enforce this as true, e.g.,
+        # hf datasets created out of data model objects.
+        return example["input"], example["output"]
+
+    @classmethod
+    def build_task_tokenize_closure(cls, *args, **kwargs) -> Tuple[Callable, bool]:
+        """Builds tokenizer closure which can be mapped over train streams to process
+        data which can then be easily passed to a DataLoader for different model types.
+        This is largely for convenience if we want a closure that can be applied
+        without having to carry around other parameters.
+        """
+        def tokenize_wrapper(example: GenerationTrainRecord):
+            return cls.tokenize_function(example, *args, **kwargs)
+        return (tokenize_wrapper, cls.REQUIRES_TOKEN_UNWRAPPING)
+
     @classmethod
     @abstractmethod
-    def build_task_tokenize_function(
-        cls,
+    def tokenize_function(cls,
+        example: Union[GenerationTrainRecord, Mapping],
         tokenizer: "AutoTokenizer",
         max_source_length: int,
         max_target_length: int,
-        verbalizer: str,
+        verbalizer: Union[None, str] = None,
         task_ids: Union[None, int] = None,
-    ) -> Tuple[Callable, bool]:
-        """Builds tokenizer functions which can be mapped over train streams to process
-        data which can then be easily passed to a DataLoader for different model types.
+    ) -> Union["BatchEncoding", DataStream["BatchEncoding"]]:
+        """Tokenizes a generation training record.
 
         Args:
+            Union[GenerationTrainRecord, Mapping]
+                Example data model object / mapping to be tokenized.
             tokenizer: AutoTokenizer
                 Model tokenizer to be used in preprocessing, i.e., when we iterate over our data.
             max_source_length: int
@@ -339,14 +380,13 @@ class PretrainedModelBase(ABC, ModuleBase):
             verbalizer: str
                 Verbalizer template to be used for formatting data. This template may use brackets
                 to indicate where fields from the data model TrainGenerationRecord must be rendered.
+                If no verbalizer is provided, the source text is used as the rendered result.
             task_ids: Union[None, int]
                 Task id corresponding particular task for multi-task prompt tuning.
                 NOTE: Only required for MPT (Multi-task prompt tuning)
                 Default: None
 
         Returns:
-            Tuple(Callable, bool)
-                Mappable tokenize function to be applied to a training stream and bool indicating
-                whether or not the stream needs to be unwrapped, i.e., each sample yields a stream
-                of 1+ samples.
+            BatchEncoding | DataStream[BatchEncoding]
+                encoded tokenization output corresponding to the input example.
         """

--- a/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_causal_lm.py
@@ -83,11 +83,13 @@ class HFAutoCausalLM(PretrainedModelBase):
             raise NotImplementedError("Verbalizer rendering not implemented for batch mode")
         source = source if verbalizer is None else render_verbalizer(verbalizer, example)
 
+        # HACK: We shouldn't have to pad here, but the causal LM data collator dynamic padding
+        # does not appear to be playing nicely with the Huggingface trainer / torch fsdp...
         source_ids = tokenizer(
-            source, max_length=max_source_length, truncation=True
+            source, max_length=max_source_length, truncation=True, padding="max_length",
         )
         target_ids = tokenizer(
-            target, max_length=max_target_length, truncation=True
+            target, max_length=max_target_length, truncation=True, padding="max_length",
         )
         if batched_mode:
             num_target_samples = []

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
@@ -15,7 +15,8 @@
 Huggingface auto causal LM resource type
 """
 # Standard
-from typing import Callable, List, Tuple, Union
+from collections.abc import Mapping
+from typing import List, Union
 
 # Third Party
 from torch.utils.data import IterableDataset
@@ -104,7 +105,6 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         trainer_arguments = {
             "train_dataset": train_dataset,
             "data_collator": data_collator,
-            # "tokenizer": self._tokenizer,
             "optimizers": optimizers,
             "eval_dataset": eval_dataset,
             # "generation_max_length": max_target_length,
@@ -133,80 +133,51 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
             tokenizer=self._tokenizer, model=self._model, **collator_kwargs
         )
 
-    @staticmethod
-    def build_task_tokenize_function(
+    @classmethod
+    def tokenize_function(
+        cls,
+        example: Union[GenerationTrainRecord, Mapping],
         tokenizer: "AutoTokenizer",
         max_source_length: int,
         max_target_length: int,
-        verbalizer: str,
+        verbalizer: Union[None, str] = None,
         task_ids: Union[None, int] = None,
-    ) -> Tuple[Callable, bool]:
-        """Builds tokenizer functions which can be mapped over train streams to process
-        data which can then be easily passed to a DataLoader for seq2seq models.
+    ) -> "BatchEncoding":
+        """Tokenization function to be used for seq2seq training; this function consumes a
+        GenerationTrainRecord object and applies the verbalizer to it followed by
+        the model tokenizer. Finally, we postprocess by ignoring pad tokens in the label IDs.
 
         Args:
-            tokenizer: AutoTokenizer
-                Model tokenizer to be used in preprocessing, i.e., when we iterate over our data.
-            max_source_length: int
-                Max length of sequences being considered.
-            max_target_length: int
-                Max length of target sequences being predicted.
-            verbalizer: str
-                Verbalizer template to be used for formatting data. This template may use brackets
-                to indicate where fields from the data model TrainGenerationRecord must be rendered.
-            task_ids: Union[None, int]
-                Task id corresponding particular task for multi-task prompt tuning.
-                NOTE: Only required for MPT (Multi-task prompt tuning)
-                Default: None
+            example: Union[GenerationTrainRecord, Mapping]
+                Training data model object to convert a form we can learn on.
 
         Returns:
-            Tuple(Callable, bool)
-                Mappable tokenize function to be applied to a training stream and bool indicating
-                whether or not the stream needs to be unwrapped, i.e., each sample yields a stream
-                of 1+ samples.
+            transformers.tokenization_utils_base.BatchEncoding
+                encoded tokenization output corresponding to the input example.
         """
+        source, target = cls.decompose_example_io(example)
+        source = source if verbalizer is None else render_verbalizer(verbalizer, example)
 
-        def tokenize_function_seq2seq(
-            example: GenerationTrainRecord,
-        ) -> "BatchEncoding":
-            """Tokenization function to be used for seq2seq training; this function consumes a
-            GenerationTrainRecord object and applies the verbalizer to it followed by
-            the model tokenizer. Finally, we postprocess by ignoring pad tokens in the label IDs.
+        model_inputs = tokenizer(
+            source,
+            max_length=max_source_length,
+            padding="max_length",
+            truncation=True,
+        )
+        labels = tokenizer(
+            target,
+            max_length=max_target_length,
+            padding="max_length",
+            truncation=True,
+        )
 
-            Args:
-                example: GenerationTrainRecord
-                    Training data model object to convert a form we can learn on.
+        labels = labels["input_ids"]
 
-            Returns:
-                transformers.tokenization_utils_base.BatchEncoding
-                    encoded tokenization output corresponding to the input example.
-            """
-            # Render the verbalizer template with the attributes of this data model example
-            source = render_verbalizer(verbalizer, example)
+        labels = list(
+            map(lambda x: IGNORE_ID if x == tokenizer.pad_token_id else x, labels)
+        )
+        model_inputs["labels"] = labels
+        if task_ids is not None:
+            model_inputs["task_ids"] = task_ids
 
-            targets = example.output
-            model_inputs = tokenizer(
-                source,
-                max_length=max_source_length,
-                padding="max_length",
-                truncation=True,
-            )
-            labels = tokenizer(
-                targets,
-                max_length=max_target_length,
-                padding="max_length",
-                truncation=True,
-            )
-
-            labels = labels["input_ids"]
-
-            labels = list(
-                map(lambda x: IGNORE_ID if x == tokenizer.pad_token_id else x, labels)
-            )
-            model_inputs["labels"] = labels
-            if task_ids is not None:
-                model_inputs["task_ids"] = task_ids
-
-            return model_inputs
-
-        return (tokenize_function_seq2seq, False)
+        return model_inputs

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq_classifier.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq_classifier.py
@@ -55,12 +55,7 @@ class HFAutoSequenceClassifier(PretrainedModelBase):
         return super().bootstrap(*args, return_dict=True, **kwargs)
 
     @staticmethod
-    def build_task_tokenize_function(
-        tokenizer: "AutoTokenizer",
-        max_source_length: int,
-        max_target_length: int,
-        verbalizer: str,
-    ) -> Tuple[Callable, bool]:
+    def build_task_tokenize_closure(*args, **kwargs) -> Tuple[Callable, bool]:
         raise NotImplementedError(
             "Tokenize func builder not implemented for sequence classifier"
         )

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq_classifier.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq_classifier.py
@@ -55,7 +55,7 @@ class HFAutoSequenceClassifier(PretrainedModelBase):
         return super().bootstrap(*args, return_dict=True, **kwargs)
 
     @staticmethod
-    def build_task_tokenize_closure(*args, **kwargs) -> Tuple[Callable, bool]:
+    def tokenize_function(*args, **kwargs) -> Tuple[Callable, bool]:
         raise NotImplementedError(
-            "Tokenize func builder not implemented for sequence classifier"
+            "Tokenize func not implemented for sequence classifier"
         )

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -176,7 +176,11 @@ def register_common_arguments(subparser: argparse.ArgumentParser) -> None:
         help="Run inference using TGIS. NOTE: This involves saving and reloading model in TGIS container",
         action="store_true",
     )
-
+    subparser.add_argument(
+        "--iterable_dataset",
+        help="Enable evaluation on trained model",
+        action="store_true",
+    )
 
 def validate_common_args(args: argparse.Namespace):
     """Validates common arguments to ensure values make sense; here, we only validate things that
@@ -227,6 +231,7 @@ def show_experiment_configuration(args, dataset_info, model_type) -> None:
         "- Enable evaluation: [{}]".format(args.evaluate),
         "- Evaluation metrics: [{}]".format(args.metrics),
         "- Torch dtype to use for training: [{}]".format(args.torch_dtype),
+        "- Using iterable dataset: [{}]".format(args.iterable_dataset)
     ]
     # Log and sleep for a few seconds in case people actually want to read this...
     print_colored("\n".join([print_str for print_str in print_strs if print_str]))
@@ -323,6 +328,7 @@ if __name__ == "__main__":
         batch_size=args.batch_size,
         accumulate_steps=args.accumulate_steps,
         num_epochs=args.num_epochs,
+        use_iterable_dataset=args.iterable_dataset,
     )
 
     print_colored("[Training Complete]")

--- a/examples/run_fine_tuning.py
+++ b/examples/run_fine_tuning.py
@@ -176,11 +176,7 @@ def register_common_arguments(subparser: argparse.ArgumentParser) -> None:
         help="Run inference using TGIS. NOTE: This involves saving and reloading model in TGIS container",
         action="store_true",
     )
-    subparser.add_argument(
-        "--iterable_dataset",
-        help="Enable evaluation on trained model",
-        action="store_true",
-    )
+
 
 def validate_common_args(args: argparse.Namespace):
     """Validates common arguments to ensure values make sense; here, we only validate things that
@@ -231,7 +227,6 @@ def show_experiment_configuration(args, dataset_info, model_type) -> None:
         "- Enable evaluation: [{}]".format(args.evaluate),
         "- Evaluation metrics: [{}]".format(args.metrics),
         "- Torch dtype to use for training: [{}]".format(args.torch_dtype),
-        "- Using iterable dataset: [{}]".format(args.iterable_dataset)
     ]
     # Log and sleep for a few seconds in case people actually want to read this...
     print_colored("\n".join([print_str for print_str in print_strs if print_str]))
@@ -332,7 +327,6 @@ if __name__ == "__main__":
         batch_size=args.batch_size,
         accumulate_steps=args.accumulate_steps,
         num_epochs=args.num_epochs,
-        use_iterable_dataset=args.iterable_dataset,
     )
 
     print_colored("[Training Complete]")

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -105,7 +105,7 @@ def test_causal_lm_tokenize_func_contains_wrapped_stream(models_cache_dir):
     causal_lm = HFAutoCausalLM.bootstrap(
         model_name=CAUSAL_LM_MODEL, tokenizer_name=CAUSAL_LM_MODEL
     )
-    (tok_func, requires_unwrapping) = causal_lm.build_task_tokenize_function(
+    (tok_func, requires_unwrapping) = causal_lm.build_task_tokenize_closure(
         tokenizer=causal_lm.tokenizer,
         max_source_length=100,
         max_target_length=100,
@@ -133,7 +133,7 @@ def test_causal_lm_tok_output_correctness(models_cache_dir):
     sample = GenerationTrainRecord(
         input="This len does not matter", output="but this one does!"
     )
-    (tok_func, requires_unwrapping) = causal_lm.build_task_tokenize_function(
+    (tok_func, requires_unwrapping) = causal_lm.build_task_tokenize_closure(
         tokenizer=causal_lm.tokenizer,
         max_source_length=100,
         max_target_length=100,
@@ -176,7 +176,7 @@ def test_seq2seq_tokenize_func_contains_unwrapped_stream(models_cache_dir):
     seq2seq = HFAutoSeq2SeqLM.bootstrap(
         model_name=SEQ2SEQ_LM_MODEL, tokenizer_name=SEQ2SEQ_LM_MODEL
     )
-    (tok_func, requires_unwrapping) = seq2seq.build_task_tokenize_function(
+    (tok_func, requires_unwrapping) = seq2seq.build_task_tokenize_closure(
         tokenizer=seq2seq.tokenizer,
         max_source_length=100,
         max_target_length=100,
@@ -202,7 +202,7 @@ def test_seq2seq_tok_output_correctness(models_cache_dir):
     sample = GenerationTrainRecord(
         input="This len does not matter", output="and this one doesn't either!"
     )
-    (tok_func, requires_unwrapping) = seq2seq.build_task_tokenize_function(
+    (tok_func, requires_unwrapping) = seq2seq.build_task_tokenize_closure(
         tokenizer=seq2seq.tokenizer,
         max_source_length=20,
         max_target_length=20,

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -19,6 +19,7 @@ import aconfig
 import caikit
 
 # Local
+from caikit.core.data_model import DataStream
 from caikit_nlp.data_model import GenerationTrainRecord
 from caikit_nlp.resources.pretrained_model import HFAutoCausalLM, HFAutoSeq2SeqLM
 from tests.fixtures import (
@@ -228,26 +229,35 @@ def test_causal_lm_batch_tokenization(models_cache_dir):
     causal_lm = HFAutoCausalLM.bootstrap(
         model_name=CAUSAL_LM_MODEL, tokenizer_name=CAUSAL_LM_MODEL
     )
-    train_stream = [
-        GenerationTrainRecord(input="foo!", output="bar!"),
-        GenerationTrainRecord(input="baz!", output="bat!"),
-        GenerationTrainRecord(input="foobar!", output="boozar!"),
-    ]
+    train_stream = DataStream.from_iterable([
+        GenerationTrainRecord(input="hello there", output="world"),
+        GenerationTrainRecord(input="how", output="today"),
+    ])
     fn_kwargs = {
         "tokenizer": causal_lm.tokenizer,
         "max_source_length": 10,
         "max_target_length": 10,
     }
+    # Create an iterable dataset by batching...
     def get(train_stream):
         for data in train_stream:
             yield {"input": data.input, "output": data.output}
     dataset = TransformersIterableDataset.from_generator(
         get, gen_kwargs={"train_stream": train_stream}
     )
-    mapped_dataset = dataset.map(
+    batched_dataset = dataset.map(
         causal_lm.tokenize_function,
         fn_kwargs=fn_kwargs,
         batched=True,
+        remove_columns=["input", "output"]
     )
-    # Ensure we can iterate over the mapped iterable dataset
-    [_ for _ in mapped_dataset]
+
+    # Do the same thing with no batching via tokenize closure + unwrapping
+    tok_func = causal_lm.build_task_tokenize_closure(**fn_kwargs)[0]
+    mapped_indiv_stream = train_stream.map(tok_func).flatten()
+    for indiv_res, batched_res in zip(mapped_indiv_stream, batched_dataset):
+        # All keys should match (input ids, attention mask)
+        assert indiv_res.keys() == batched_res.keys()
+        # And all of their values should be the same
+        for k in indiv_res:
+            assert indiv_res[k] == batched_res[k]

--- a/tests/resources/test_pretrained_model.py
+++ b/tests/resources/test_pretrained_model.py
@@ -27,6 +27,16 @@ from tests.fixtures import (
     temp_cache_dir,
 )
 
+def test_bootstrap_with_preloaded_tokenizer(models_cache_dir):
+    """Ensure that if we have a tokenizer instance, we can bootstrap with it directly."""
+    tok_instance = transformers.AutoTokenizer.from_pretrained(CAUSAL_LM_MODEL)
+    base_model = HFAutoCausalLM.bootstrap(
+        model_name=CAUSAL_LM_MODEL, tokenizer_name=tok_instance
+    )
+    assert isinstance(base_model, HFAutoCausalLM)
+    assert base_model.MODEL_TYPE is transformers.AutoModelForCausalLM
+    assert base_model.TASK_TYPE == "CAUSAL_LM"
+
 
 def test_boostrap_causal_lm(models_cache_dir):
     """Ensure that we can bootstrap a causal LM if we have download access."""


### PR DESCRIPTION
- Adds support for normal style datasets in text generation fine tuning
- Adds flag to support iterable dataset toggle in fine tuning script
- Fixes a bug in logging; `.name` -> `.__name__` (currently warning fatally crashes)
- Exposes max restarts as a param in torch launch config; default is 3, which matches the library default, but given that fdsp experiments can be slow to iterate one, it can be nice to manually set this when iterating
- Updates the base model resource to allow direct passing of tokenizer
- Leverages that ^ in the trainer to fix a bug in the (lack of) tokenizer export in fine-tuning text generation models
- Rewrites tokenizer builder function to be closure builders around named functions
- Removes hack for seq2seq standalone tokenize function & uses base model named tokenizer functions ^
- Enables shuffling on HF datasets for fine tuning (first epoch only)
- Allow for omitted verbalizer at tokenization time
- Update tokenize functions to work mapping classes, e.g,. dictionaries & HF dataset Lazyrow objects, in addition to generation training data model objects 
- Adds (very disgusting) support for batch tokenization for causal LM
- Enables iterable datasets for causal lm and seq2seq on fine tuning
- Adds method for inferring max steps for iterable datsets