### PR TITLE
:bandaid::package: Fix peft installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,11 @@ dependencies = [
     "torch>=1.13.1",
     "tqdm>=4.65.0",
     "transformers>=4.31.0",
-    "peft@git+https://github.com/mayank31398/peft.git@mpt-os-test"
+    # GK-AUG-25-2023 NOTE: mpt branch on Mayank's fork was merged to peft main on Aug 24 and it got deleted
+    # which broke caikit-nlp build. peft hasn't released newer version yet, so to get
+    # the build fix, we pulling peft from main branch commit. In future, we will pull PEFT from
+    # pypi
+    "peft@git+https://github.com/huggingface/peft.git#8c17d556a8fe9522e10d73d7bd3fad46a6ecae14"
 ]
 
 [project.urls]


### PR DESCRIPTION
### Changes
- MPT peft PR got merged to peft main repo last night and branch on mayank's repo got deleted. This broke caikit-nlp build. To get it working again, for now we are peft+mpt from main branch of peft repo since latest version hasn't released yet.