### PR TITLE
Add support for FSDP prompt tuning

### DIFF
--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -72,8 +72,8 @@ from ...toolkit.text_generation.training_utils import (
     launch_training,
     preprocess_function,
 )
-from ...toolkit.verbalizer_utils import render_verbalizer
 from ...toolkit.torch_run import get_torch_elastic_launch_config
+from ...toolkit.verbalizer_utils import render_verbalizer
 from .peft_config import TuningType, get_peft_config, resolve_base_model
 
 log = alog.use_channel("PEFT_PROMPT")
@@ -354,7 +354,6 @@ class PeftPromptTuning(ModuleBase):
 
         torch_dtype = get_torch_dtype(torch_dtype)
 
-
         # NOTE: We are not support "metrics" at the moment
 
         # Coerce the passed model into a resource; if we have one, this is a noop
@@ -464,8 +463,9 @@ class PeftPromptTuning(ModuleBase):
                     # this generic approach, since it allows us to handle variety
                     # of models and iterate on it, based on what we encounter.
                     "fsdp_transformer_layer_cls_to_wrap": base_model._model._no_split_modules,
-                    # We need to use the original parameters for peft because we have mixed values for
-                    # require_grads in our parametes, which otherwise breaks layer flattening in FSDP.
+                    # We need to use the original parameters for peft because we have mixed values
+                    # for require_grads in our parametes, which otherwise breaks layer flattening
+                    # in FSDP.
                     "use_orig_params": "true",
                 },
             }
@@ -489,7 +489,6 @@ class PeftPromptTuning(ModuleBase):
                 **processing_configuration,
             )
 
-
             if torch.cuda.is_available():
                 # NOTE: torch distributed can hang if run on CPUs,
                 # to avoid that, specially for unit tests, we are only
@@ -506,7 +505,7 @@ class PeftPromptTuning(ModuleBase):
                     training_dataset,
                     training_args,
                     checkpoint_dir,
-                    base_model
+                    base_model,
                 )
                 # NOTE: We are currently only storing the loss information from
                 # rank 0, i.e main process. training_loss_history is dictionary containing

--- a/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
+++ b/caikit_nlp/modules/text_generation/peft_prompt_tuning.py
@@ -38,6 +38,7 @@ import torch
 import transformers
 
 # First Party
+from caikit import get_config
 from caikit.core.data_model import DataStream
 from caikit.core.exceptions import error_handler
 from caikit.core.modules import ModuleBase, ModuleConfig, ModuleSaver, module
@@ -72,6 +73,7 @@ from ...toolkit.text_generation.training_utils import (
     preprocess_function,
 )
 from ...toolkit.verbalizer_utils import render_verbalizer
+from ...toolkit.torch_run import get_torch_elastic_launch_config
 from .peft_config import TuningType, get_peft_config, resolve_base_model
 
 log = alog.use_channel("PEFT_PROMPT")
@@ -364,7 +366,7 @@ class PeftPromptTuning(ModuleBase):
         # enabled and then configures the tensors it creates with appropriate
         # setting. If we do not enable this, then we will get `tensor 0` requires
         # grad error, where `tensor 0` is created by peft
-        base_model.model.gradient_checkpointing_enable()
+        # base_model.model.gradient_checkpointing_enable()
 
         base_model_name = base_model._model_name
         # Get config of the base model
@@ -449,6 +451,25 @@ class PeftPromptTuning(ModuleBase):
                 training_metadata={"loss": []},
             )
 
+        processing_configuration = {}
+
+        # Conditionally enable sharding if multiple GPUs available
+        if torch.cuda.is_available() and torch.cuda.device_count() > 1:
+            processing_configuration = {
+                "fsdp": "full_shard offload auto_wrap",
+                "fsdp_config": {
+                    # NOTE: Every transformers model has `_no_split_modules` property that can be
+                    # leveraged to identify the layers to split. This seems to be a decent
+                    # "default" behavior unless we want to optimize further. We will start with
+                    # this generic approach, since it allows us to handle variety
+                    # of models and iterate on it, based on what we encounter.
+                    "fsdp_transformer_layer_cls_to_wrap": base_model._model._no_split_modules,
+                    # We need to use the original parameters for peft because we have mixed values for
+                    # require_grads in our parametes, which otherwise breaks layer flattening in FSDP.
+                    "use_orig_params": "true",
+                },
+            }
+
         # Open an intermediate checkpoint directory until we've bootstrapped
         # our model or we've early exited (if epochs < 1)
         with tempfile.TemporaryDirectory() as checkpoint_dir:
@@ -465,20 +486,41 @@ class PeftPromptTuning(ModuleBase):
                 silence_progress_bars=silence_progress_bars,
                 # NOTE: following can override above arguments in order
                 **filtered_training_arguments,
+                **processing_configuration,
             )
 
-            base_model_trainer = base_model.get_trainer(
-                train_dataset=training_dataset, model=peft_model, **training_args
-            )
 
-            training_loss_history = launch_training(
-                peft_model,
-                training_dataset,
-                training_args,
-                checkpoint_dir,
-                trainer=base_model_trainer,
-                tokenizer=base_model.tokenizer,
-            )
+            if torch.cuda.is_available():
+                # NOTE: torch distributed can hang if run on CPUs,
+                # to avoid that, specially for unit tests, we are only
+                # running below when GPUs are available
+                launch_config = get_torch_elastic_launch_config(
+                    get_config().master_addr,
+                    get_config().master_port,
+                )
+
+                training_loss_history = torch.distributed.launcher.api.elastic_launch(
+                    launch_config, launch_training
+                )(
+                    peft_model,
+                    training_dataset,
+                    training_args,
+                    checkpoint_dir,
+                    base_model
+                )
+                # NOTE: We are currently only storing the loss information from
+                # rank 0, i.e main process. training_loss_history is dictionary containing
+                # rank of the process as key
+                training_loss_history = training_loss_history[0]
+            else:
+                # Do not do FSDP things
+                training_loss_history = launch_training(
+                    peft_model,
+                    training_dataset,
+                    training_args,
+                    checkpoint_dir,
+                    base_model,
+                )
 
         # Remove _name_or_path field as a model can be
         # saved in different location but still same

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
@@ -114,7 +114,7 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         """
 
         # NOTE: predict_with_generate is incompatible with fsdp
-        training_args = Seq2SeqTrainingArguments(**kwargs)
+        training_args = Seq2SeqTrainingArguments(**kwargs) ### TODO: investigate hanging here!!
 
         # pylint: disable=duplicate-code
         # TODO: Fetch DataCollator either from property of this

--- a/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
+++ b/caikit_nlp/resources/pretrained_model/hf_auto_seq2seq_lm.py
@@ -114,7 +114,7 @@ class HFAutoSeq2SeqLM(PretrainedModelBase):
         """
 
         # NOTE: predict_with_generate is incompatible with fsdp
-        training_args = Seq2SeqTrainingArguments(**kwargs) ### TODO: investigate hanging here!!
+        training_args = Seq2SeqTrainingArguments(**kwargs)
 
         # pylint: disable=duplicate-code
         # TODO: Fetch DataCollator either from property of this

--- a/caikit_nlp/toolkit/text_generation/training_utils.py
+++ b/caikit_nlp/toolkit/text_generation/training_utils.py
@@ -186,7 +186,6 @@ def launch_training(
         else:
             error("<NLP26155082E>", "could not resolve trainer. Check base model type!")
 
-    #breakpoint()
 
     # Start training via Trainer.train function
     result = trainer.train()

--- a/caikit_nlp/toolkit/text_generation/training_utils.py
+++ b/caikit_nlp/toolkit/text_generation/training_utils.py
@@ -132,7 +132,7 @@ def preprocess_function(
     shuffle: bool,
     use_iterable_dataset: bool,
     random_seed: int,
-    task_ids: Optional[List[int]] = None
+    task_ids: Optional[List[int]] = None,
 ):
     """Pre-process each example to get it prepared for training."""
     dataset_type = TransformersIterableDataset if use_iterable_dataset else Dataset
@@ -154,7 +154,7 @@ def preprocess_function(
         fn_kwargs=fn_kwargs,
         # For now, we hardcode to False, since causal LM chunking is not exposed yet
         batched=False,
-        #batched=base_model.REQUIRES_TOKEN_UNWRAPPING,
+        # batched=base_model.REQUIRES_TOKEN_UNWRAPPING,
         # Drop the input / output columns; we need to do this for dimensions to play
         # happily when operating on batched inputs for causal language modeling.
         remove_columns=["input", "output"],
@@ -190,11 +190,8 @@ def launch_training(
         else:
             error("<NLP26155082E>", "could not resolve trainer. Check base model type!")
 
-
     # Start training via Trainer.train function
     result = trainer.train()
-
-
 
     # Log the output of the training. This will include stats about training
     log.info("<NLP22028223I>", "Training completed. Summary: {}".format(result))

--- a/examples/run_peft_tuning.py
+++ b/examples/run_peft_tuning.py
@@ -395,7 +395,9 @@ if __name__ == "__main__":
         train_stream = subsample_stream(train_stream, args.num_shots)
     # Init the resource & Build the tuning config from our dataset/arg info
     print_colored("[Loading the base model resource...]")
-    base_model = model_type.bootstrap(args.model_name, tokenizer_name=args.model_name, torch_dtype=args.torch_dtype)
+    base_model = model_type.bootstrap(
+        args.model_name, tokenizer_name=args.model_name, torch_dtype=args.torch_dtype
+    )
     tuning_config = build_tuning_config(args, dataset_info)
     # Then actually train the model & save it
     print_colored("[Starting the training...]")


### PR DESCRIPTION
Adds support for multiGPU prompt tuning through FSDP / trainer. Minimal example showing this working using a small T5 model:

```
ALLOW_DOWNLOADS=true MASTER_ADDR=localhost MASTER_PORT=25590 WORLD_SIZE=2 RANK=0  LOG_LEVEL=debug python3 run_peft_tuning.py PROMPT_TUNING   --dataset "glue/rte"    --model_name t5-small   --num_epochs 1 --verbose   --prompt_tuning_init RANDOM    --output_dir prompt_prefixes/alex_t5_pt   --learning_rate 0.3   --batch_size=2   --accumulate_steps 16   --max_target_length 1   --max_source_length 1
```

